### PR TITLE
Small change to do https

### DIFF
--- a/lib/node.io/request.js
+++ b/lib/node.io/request.js
@@ -174,7 +174,9 @@ Job.prototype.doRequest = function (method, resource, body, headers, callback, p
         port = (url.protocol === 'http:') ? 80 : 443;
     }
         
-    var host = http.createClient(port, url.hostname),
+    var secure = (url.protocol == 'https:') ? true : false;
+
+    var host = http.createClient(port, url.hostname, secure),
         req_url = url.pathname;
     
     if (typeof headers.host === 'undefined') {


### PR DESCRIPTION
As per the commit message:

Small change to do Https.  Not sure when the secure flag was added, but
this wasn't working in node 0.2.5 or 0.2.6.  Without the secure flag,
node will attempt to open the socket and perform the http get without
first performing an SSL handshake.
