### PR TITLE
Make Job.prototype.doRequest copy headers before modifying

### DIFF
--- a/lib/node.io/request.js
+++ b/lib/node.io/request.js
@@ -177,6 +177,9 @@ Job.prototype.doRequest = function (method, resource, body, headers, callback, p
     var host = http.createClient(port, url.hostname),
         req_url = url.pathname;
     
+    //Copy `headers` before modifying it
+    headers = utils.put({}, headers);
+    
     if (typeof headers.host === 'undefined') {
         headers.host = url.hostname;
     }


### PR DESCRIPTION
The upstream version of `Job.prototype.doRequest` directly modifies the `headers` parameter, e.g. to insert a Host header from the `url.hostname`. This is problematic, however, because in many cases `headers = default_headers`.

Without this change, the first address accessed gets its Host: header set into `default_headers`. Since headers.host is only set if not set, it is not overridden by subsequent requests, thus causing them to be sent with the wrong Host: header.

For example:
    class TestCase extends (require 'node.io').JobClass
      input: ['us','eu']
      run: (region) ->
        @get 'http://'+region+'.battle.net/', (err) =>
          if err
            @exit err
          else
            @emit "ok"

```
@class = TestCase
@job = new TestCase
```

Causes:

```
12.129.242.40 (us.battle.net)
GET / HTTP/1.1
accept: */*
accept-charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
user-agent: node.io
host: us.battle.net
Connection: close

80.239.186.40 (eu.battle.net)
GET / HTTP/1.1
accept: */*
accept-charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
user-agent: node.io
host: us.battle.net
referer: http://us.battle.net/
cookie: perm=1; Domain=battle.net; Path=/
Connection: close
```
