### PR TITLE
Gracefully handle webpages that cannot be parsed with jsdom/jQuery

### DIFF
--- a/lib/node.io/dom.js
+++ b/lib/node.io/dom.js
@@ -50,12 +50,18 @@ Job.prototype.parseHtml = function (data, callback, response) {
                 ProcessExternalResources: this.options.external_resources,
                 QuerySelector: false
         };
-        var $, window = require('jsdom').jsdom(data, null, {features:features}).createWindow(),
-            jquery = require('jquery')
+        var $, window, jquery, default_$;
+        try {
+            window = require('jsdom').jsdom(data, null, {features:features}).createWindow();
+            jquery = require('jquery');
             default_$ = jquery.create(window);
-        $ = function (selector, context) {
-            return context ? jquery.create(context)(selector) : default_$(selector);
-        };
+            $ = function (selector, context) {
+                return context ? jquery.create(context)(selector) : default_$(selector);
+            };
+        } catch (e) {
+            callback.apply(self, [e, $, data, headers, response]);
+            return;
+        }
         if (recurse === 1 || recurse === true || recurse instanceof Array) {
             this.recurseUrls($);
         }


### PR DESCRIPTION
This adds a try/catch block around the initialization of jsdom/jQuery for a fetched webpage and returns the exception (if any) as the callback err parameter instead of crashing the node.io process.
