### PR TITLE
Add response.url parameter and give jsdom proper URLs

### DIFF
--- a/lib/node.io/dom.js
+++ b/lib/node.io/dom.js
@@ -52,7 +52,7 @@ Job.prototype.parseHtml = function (data, callback, response) {
         };
         var $, window, jquery, default_$;
         try {
-            window = require('jsdom').jsdom(data, null, {features:features}).createWindow();
+            window = require('jsdom').jsdom(data, null, {features:features, url:response.url}).createWindow();
             jquery = require('jquery');
             default_$ = jquery.create(window);
             $ = function (selector, context) {

--- a/lib/node.io/request.js
+++ b/lib/node.io/request.js
@@ -311,6 +311,8 @@ Job.prototype.doRequest = function (method, resource, body, headers, callback, p
 
     request = (secure ? https : http).request(options, function (response) {
 
+        response.url = resource;
+
         request_reponse = response;
 
         if (self.is_complete) {


### PR DESCRIPTION
If jsdom is not given an options.url property, it will default to using the current script filename as the URL. This messes with the automatic path resolution in jQuery and causes the following code:

```
$('a[href]').each(function(i, a) { console.log(a.href); }
```

To print URLs like:

```
/home/ubuntu/myapp/node_modules/node.io/lib/node.io/relative/web/path/
```

To fix this, I added a url property to the response object which parseHtml() passes into the jsdom() method.
