### PR TITLE
option to not throw an error if selector does not exist

### DIFF
--- a/lib/node.io/dom.js
+++ b/lib/node.io/dom.js
@@ -15,14 +15,18 @@ var Job = require('./job').JobProto,
  * @param {Function} context
  * @api public
  */
-Job.prototype.$ = function (selector, context) {
+Job.prototype.$ = function (selector, context, suppressErrors) {
+    suppressErrors = suppressErrors || false;
     if (!soupselect) {
         soupselect = require('../../vendor/soupselect').select;
     }
     var selected = soupselect(context, selector);
     if (selected.length === 0) {
         this.debug('\x1B[31mERR\x1B[0m No elements matching "' + selector + '"');
-        throw new Error("No elements matching '" + selector + "'");
+        if (suppressErrors)
+          selected = false;
+        else
+          throw new Error("No elements matching '" + selector + "'");
     } else if (selected.length === 1) {
         selected = selected[0];
         this.bindToDomElement(selected);
@@ -72,9 +76,9 @@ Job.prototype.parseHtml = function (data, callback, response) {
             if (err) {
                 callback.call(self, err);
             } else {
-                $ = function (selector, context) {
+                $ = function (selector, context, suppressErrors) {
                     //Allow the user to specify a custom context (thanks to github.com/jimbishopp)
-                    return self.$(selector, context || dom);
+                    return self.$(selector, context || dom, suppressErrors);
                 };
                 if (recurse === 1 || recurse === true || recurse instanceof Array) {
                     self.recurseUrls($);


### PR DESCRIPTION
added suppressErrors as a third argument to $ function, and if true, return false (instead of throwing an error) if selector does not exist
