### PR TITLE
Fixing binary name (now it is `io` and no more `node.io`).

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,20 @@ node.io comes with some [built-in scraping modules](https://github.com/chriso/no
 
 Find the pagerank of a domain
 
-    $ echo "mastercard.com" | node.io pagerank
+    $ echo "mastercard.com" | io pagerank
        => mastercard.com,7
 
 ..or a list of URLs
 
-    $ node.io pagerank < urls.txt
+    $ io pagerank < urls.txt
 
 Quickly check the http code for each URL in a list
 
-    $ node.io statuscode < urls.txt
+    $ io statuscode < urls.txt
 
 Grab the front page stories from [reddit](http://www.reddit.com)
 
-    $ node.io query "http://www.reddit.com/" a.title
+    $ io query "http://www.reddit.com/" a.title
 
 ## Installation
 


### PR DESCRIPTION
When installing node.io, the `node.io` binary is not available while `io` yes.

<pre><code>npm install -g node.io
npm WARN htmlparser@1.7.3 package.json: bugs['web'] should probably be bugs['url']

> contextify@0.0.7 preinstall /usr/local/lib/node_modules/node.io/node_modules/jsdom/node_modules/contextify
> node-waf clean || true; node-waf configure build

Nothing to clean (project not configured)
Setting srcdir to                        : /usr/local/lib/node_modules/node.io/node_modules/jsdom/node_modules/contextify 
Setting blddir to                        : /usr/local/lib/node_modules/node.io/node_modules/jsdom/node_modules/contextify/build 
Checking for program g++ or c++          : /usr/bin/g++ 
Checking for program cpp                 : /usr/bin/cpp 
Checking for program ar                  : /usr/bin/ar 
Checking for program ranlib              : /usr/bin/ranlib 
Checking for g++                         : ok  
Checking for node path                   : not found 
Checking for node prefix                 : ok /usr/local/Cellar/node/0.6.2 
'configure' finished successfully (0.030s)
Waf: Entering directory `/usr/local/lib/node_modules/node.io/node_modules/jsdom/node_modules/contextify/build'
[1/2] cxx: src/contextify.cc -> build/Release/src/contextify_1.o
[2/2] cxx_link: build/Release/src/contextify_1.o -> build/Release/contextify.node
Waf: Leaving directory `/usr/local/lib/node_modules/node.io/node_modules/jsdom/node_modules/contextify/build'
'build' finished successfully (0.281s)
/usr/local/bin/io -> /usr/local/lib/node_modules/node.io/bin/io
/usr/local/bin/node.io -> /usr/local/lib/node_modules/node.io/bin/node.io
/usr/local/bin/node.io-web -> /usr/local/lib/node_modules/node.io/bin/node.io-web
node.io@0.4.7 /usr/local/lib/node_modules/node.io 
├── jquery@1.6.3
├── request@2.9.3
├── coffee-script@1.2.0
├── htmlparser@1.7.3
└── jsdom@0.2.10</code></pre>
