### PR TITLE
Support for various Coffee based compilers

### DIFF
--- a/lib/node.io/interfaces/cli.js
+++ b/lib/node.io/interfaces/cli.js
@@ -30,6 +30,7 @@ var usage = ''
   + '  -g, --debug            Debug the operation\n'
   + '  -v, --version          Display the current version\n'
   + '  -h, --help             Display help information\n'
+  + '  -c, --compiler         Set an alternate compiler to use\n'
   ;
 
 /**
@@ -117,6 +118,10 @@ exports.cli = function (args, exit) {
         case '-u':
         case '--unpack':
             options.unpack = args.shift();
+            break;
+        case '-c':
+        case '--compiler':
+            options.compiler = args.shift();
             break;
         default:
             job_path = arg;

--- a/lib/node.io/processor.js
+++ b/lib/node.io/processor.js
@@ -335,7 +335,7 @@ Processor.prototype.loadJob = function (job, options, callback) {
                 //If we're the master, compile and load the .coffee file
                 this.status('Compiling ' + job + ' => ' + compiled_js, 'debug');
 
-                utils.compileCoffee(job, compiled_js, function(err) {
+                utils.compile(options.compiler || 'coffee', job, compiled_js, function(err) {
                     if (err) {
                         callback(err);
                     } else {

--- a/lib/node.io/utils.js
+++ b/lib/node.io/utils.js
@@ -79,9 +79,20 @@ exports.removeOnExit = function (file) {
  * @api public
  */
 exports.compileCoffee = function (coffee_file, compiled_file, callback) {
-    exec('coffee -p -c "' + coffee_file + '"', {cwd: cwd}, function (err, stdout, stderr) {
+    exec('iced -p -c "' + coffee_file + '"', {cwd: cwd}, function (err, stdout, stderr) {
         if (err || stderr) {
-            callback(err || stderr);
+            if (!stderr || (stderr && stderr.indexOf("iced: not found") === -1)) {
+                callback(err || stderr);
+            } else {
+                exec('coffee -p -c "' + coffee_file + '"', {cwd: cwd}, function (err, stdout, stderr) {
+                    if (err || stderr) {
+                        callback(err || stderr);
+                    } else {
+                        exports.removeOnExit(compiled_file);
+                        fs.writeFile(compiled_file, stdout, callback);
+                    }
+                });
+            }
         } else {
             exports.removeOnExit(compiled_file);
             fs.writeFile(compiled_file, stdout, callback);

--- a/lib/node.io/utils.js
+++ b/lib/node.io/utils.js
@@ -78,21 +78,10 @@ exports.removeOnExit = function (file) {
  * @param {Function} callback
  * @api public
  */
-exports.compileCoffee = function (coffee_file, compiled_file, callback) {
-    exec('iced -p -c "' + coffee_file + '"', {cwd: cwd}, function (err, stdout, stderr) {
+exports.compile = function (compiler, coffee_file, compiled_file, callback) {
+    exec(compiler + ' -p -c "' + coffee_file + '"', {cwd: cwd}, function (err, stdout, stderr) {
         if (err || stderr) {
-            if (!stderr || (stderr && stderr.indexOf("iced: not found") === -1)) {
-                callback(err || stderr);
-            } else {
-                exec('coffee -p -c "' + coffee_file + '"', {cwd: cwd}, function (err, stdout, stderr) {
-                    if (err || stderr) {
-                        callback(err || stderr);
-                    } else {
-                        exports.removeOnExit(compiled_file);
-                        fs.writeFile(compiled_file, stdout, callback);
-                    }
-                });
-            }
+            callback(err || stderr);
         } else {
             exports.removeOnExit(compiled_file);
             fs.writeFile(compiled_file, stdout, callback);


### PR DESCRIPTION
There is now a simple command line option of `-c/--compiler` which will take the name of the compiler and defaults to coffee. This will help add support for [IcedCoffeeScript](http://maxtaco.github.com/coffee-script/), [Coco](https://github.com/satyr/coco), and [LiveScript](http://gkz.github.com/LiveScript/) as they all have the same cli options and are based off of CoffeeScript.

It wouldn't be much more work from this to support any compiler in the future.
