### PR TITLE
new way to identify a job 

### DIFF
--- a/lib/node.io/processor.js
+++ b/lib/node.io/processor.js
@@ -266,7 +266,7 @@ Processor.prototype.loadJob = function (job, options, callback) {
 
         //The job is already loaded. Since we don't have a unique job
         //name, give the job a unique ID before starting
-        var job_id = utils.crc32(JSON.stringify(job));
+        var job_id = utils.crc32(new Date().getTime());
         this.processJob(job_id, job, options, callback);
 
     } else if (typeof job === 'string') {
@@ -444,7 +444,7 @@ Processor.prototype.startJob = function (job_name, job_obj, oncomplete) {
  */
 Processor.prototype.endJob = function (job) {
     if (typeof job === 'object') {
-        job = utils.crc32(JSON.stringify(job));
+        job = utils.crc32(new Date().getTime());
     }
     for (var i = 0, l = this.jobs.length; i < l; i++) {
         if (this.jobs[i].job_name == job) {


### PR DESCRIPTION
if you want to pass some vars to a job,
the only way, without using globals, is to pass them through joboption
( e.g nodeio.start(jobNew, joboption, ... )

But when your vars can't be JSON.stringified (i.e streams), you are stuck.
