### PR TITLE
Seems like a pretty simple fix, did the trick.

### DIFF
--- a/lib/node.io/interfaces/cli.js
+++ b/lib/node.io/interfaces/cli.js
@@ -87,6 +87,7 @@ exports.cli = function (args, exit) {
         case '-m':
         case '--max':
             options.max = args.shift();
+            break;
         case '-t':
         case '--timeout':
             options.global_timeout = args.shift();


### PR DESCRIPTION
Docs could also use something specifying that this will not work with standard getopt syntax, -mN does not work, only -m N.  Similarly --max=N will not work.

Using the node getopt library seems like it would be useful here, no?
