### PR TITLE
Cookie values incorrectly URI encoded

### DIFF
--- a/lib/node.io/request.js
+++ b/lib/node.io/request.js
@@ -374,7 +374,7 @@ Job.prototype.setHeader = function (key, value) {
  */
 Job.prototype.setCookie = function (key, value) {
     if (value) {
-        key = encodeURIComponent(key) + '=' + encodeURIComponent(value);
+        key = encodeURIComponent(key) + '=' + value;
     }
     this.setHeader('cookie', key);
 };
@@ -398,7 +398,7 @@ Job.prototype.setUserAgent = function (agent) {
  */
 Job.prototype.addCookie = function (key, value) {
     key = encodeURIComponent(key);
-    value = encodeURIComponent(value);
+    value = value;
     if (typeof this.next.cookie !== 'undefined' && this.next.cookie.length) {
         this.next.cookie += '; ' + key + '=' + value;
     } else {


### PR DESCRIPTION
Cookie values do not need to be URI encoded.
