### PR TITLE
require.paths was removed in node.js

### DIFF
--- a/lib/node.io/interfaces/web.js
+++ b/lib/node.io/interfaces/web.js
@@ -44,9 +44,10 @@ exports.web = function (args, exit) {
     var port = 8080, daemonize = false, daemon_arg;
 
     var module_dir;
-    for (var i = 0, l = require.paths.length; i < l; i++) {
-        if (require.paths[i].indexOf('.node_modules') >= 0) {
-            module_dir = require.paths[i];
+    var requirePaths = process.env.NODE_PATH.split(':');
+    for (var i = 0, l = requirePaths.length; i < l; i++) {
+        if (requirePaths[i].indexOf('.node_modules') >= 0) {
+            module_dir = requirePaths[i];
             break;
         }
     }


### PR DESCRIPTION
In recent versions of node.js, require.paths was removed. This causes node.io-web to throw an error when started.

Fixed in the PR
